### PR TITLE
feat: 프로필 삭제 기능 구현, 프로필 중복 삭제요청시 예외처리, BaseEntity @Setter 추가

### DIFF
--- a/src/main/java/com/spring/instafeed/base/BaseEntity.java
+++ b/src/main/java/com/spring/instafeed/base/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.CreatedDate;
@@ -30,10 +31,14 @@ public abstract class BaseEntity {
     )
     private LocalDateTime updatedAt;
 
+    // isDeleted 값을 설정할 수 있는 메서드 추가
+    @Setter
     @Comment("삭제 여부")
     @Column(name = "is_deleted", columnDefinition = "TINYINT(0)")
-    private Boolean isDeleted;
+    private Boolean isDeleted=false;
 
+    // 삭제일을 설정할 수 있는 메서드 추가
+    @Setter
     @Comment("삭제일")
     @Column(name = "deleted_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime deletedAt;

--- a/src/main/java/com/spring/instafeed/profile/controller/ProfileController.java
+++ b/src/main/java/com/spring/instafeed/profile/controller/ProfileController.java
@@ -3,10 +3,13 @@ package com.spring.instafeed.profile.controller;
 import com.spring.instafeed.profile.dto.request.CreateProfileRequestDto;
 import com.spring.instafeed.profile.dto.request.UpdateProfileRequestDto;
 import com.spring.instafeed.profile.dto.response.CreateProfileResponseDto;
+import com.spring.instafeed.profile.dto.response.DeleteProfileResponseDto;
 import com.spring.instafeed.profile.dto.response.UpdateProfileResponseDto;
 import com.spring.instafeed.profile.service.ProfileService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -15,26 +18,27 @@ import java.util.List;
 @RequestMapping("/profiles")
 public class ProfileController {
 
-    /**
-     * ProfileService 객체
-     *
-     * 프로필 생성, 조회, 수정 등 실제 비즈니스 로직을 처리하는 서비스 클래스.
-     */
     private final ProfileService profileService;
 
     /**
      * 프로필 생성
      *
-     * POST 요청을 통해 새로운 프로필을 생성하는 엔드포인트.
-     * 요청 본문에서 받은 사용자 ID와 프로필 정보를 바탕으로 새로운 프로필을 생성한다.
+     * 요청 본문에서 `userId`와 프로필 정보를 바탕으로 새로운 프로필을 생성합니다.
+     * 생성된 프로필은 데이터베이스에 저장되고, 저장된 프로필 정보를 DTO로 변환하여 반환합니다.
      *
-     * @param createProfileRequestDto 프로필 생성 요청 DTO
-     * @return 생성된 프로필 정보를 담은 Response DTO
+     * @param createProfileRequestDto  프로필 생성 요청 DTO (userId 포함)
+     * @return createProfileResponseDto 생성된 프로필 정보를 담은 응답 DTO
+     * @throws ResponseStatusException 사용자 ID가 null이거나, 사용자가 존재하지 않으면 예외 발생
+     * @throws ResponseStatusException 닉네임이 중복되는 경우 예외 발생
      */
     @PostMapping
-    public CreateProfileResponseDto createProfile(@RequestBody CreateProfileRequestDto createProfileRequestDto) {
-        return profileService.createProfile(createProfileRequestDto.getUserId(), createProfileRequestDto);
+    public CreateProfileResponseDto createProfile(
+            @RequestBody CreateProfileRequestDto createProfileRequestDto) {  // 요청 본문에서 프로필 정보 받음
+
+        // userId를 요청 본문에서 받아서 서비스 메서드에 전달
+        return profileService.createProfile(createProfileRequestDto.getUserId(), createProfileRequestDto);  // userId와 DTO 전달
     }
+
 
     /**
      * 프로필 목록 조회
@@ -64,17 +68,32 @@ public class ProfileController {
     }
 
     /**
-     * 프로필 수정
+     * 프로필 수정 API
      *
-     * PUT 요청을 통해 특정 프로필을 수정하는 엔드포인트.
-     * 주어진 프로필 ID와 수정된 내용을 바탕으로 프로필 정보를 업데이트한다.
+     * 주어진 프로필 ID를 이용하여 프로필 정보를 수정합니다.
+     * 프로필이 존재하지 않으면 예외가 발생합니다.
      *
-     * @param id 수정할 프로필의 ID
-     * @param updatedProfileRequestDto 수정된 프로필 정보 DTO
-     * @return 수정된 프로필 정보를 담은 Response DTO
+     * @param id 프로필 ID (URL 경로에서 전달받음)
+     * @param updatedProfileRequestDto 수정할 프로필 정보를 담은 요청 DTO
+     * @return 수정된 프로필 정보를 담은 응답 DTO
      */
-    @PutMapping("/{id}")
-    public UpdateProfileResponseDto updateProfile(@PathVariable Long id, @RequestBody UpdateProfileRequestDto updatedProfileRequestDto) {
-        return profileService.updateProfile(id, updatedProfileRequestDto);
+    @PutMapping("/{profileId}")
+    public UpdateProfileResponseDto updateProfile(
+            @PathVariable("profileId") Long id,  // URL에서 사용자 ID를 받음
+            @RequestBody UpdateProfileRequestDto updatedProfileRequestDto) {  // 수정할 프로필 정보 받음
+        return profileService.updateProfile(id, updatedProfileRequestDto);  // 매개변수 이름을 전달
+    }
+
+
+    /**
+     * 프로필 삭제
+     * 특정 프로필을 논리적으로 삭제하는 엔드포인트입니다.
+     *
+     * @param id 삭제할 프로필의 ID
+     * @return 삭제된 프로필 정보
+     */
+    @DeleteMapping("/{id}")
+    public DeleteProfileResponseDto deleteProfile(@PathVariable Long id) {
+        return profileService.deleteProfile(id);
     }
 }

--- a/src/main/java/com/spring/instafeed/profile/dto/response/DeleteProfileResponseDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/response/DeleteProfileResponseDto.java
@@ -2,14 +2,13 @@ package com.spring.instafeed.profile.dto.response;
 
 import com.spring.instafeed.profile.entity.Profile;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class UpdateProfileResponseDto {
+public class DeleteProfileResponseDto {
 
     private final Long id;
     private final Long userId;
@@ -22,17 +21,17 @@ public class UpdateProfileResponseDto {
     private final LocalDateTime deletedAt;
 
     /**
-     * Profile 객체를 UpdateProfileResponseDto로 변환하는 static 메서드
+     * Profile 객체를 DeleteProfileResponseDto로 변환하는 static 메서드
      *
-     * 이 메서드는 주어진 Profile 엔티티 객체를 UpdateProfileResponseDto 객체로 변환하여 반환합니다.
+     * 이 메서드는 주어진 Profile 엔티티 객체를 DeleteProfileResponseDto 객체로 변환하여 반환합니다.
      * 주로 응답 데이터 포맷으로 변환할 때 사용됩니다.
      * 변환된 DTO 객체는 클라이언트에게 전달될 JSON 형태로 변환되어 응답에 포함됩니다.
      *
      * @param profile 변환할 Profile 엔티티 객체
-     * @return Profile을 기반으로 생성된 UpdateProfileResponseDto 객체
+     * @return Profile을 기반으로 생성된 DeleteProfileResponseDto 객체
      */
-    public static UpdateProfileResponseDto of(Profile profile) {
-        return new UpdateProfileResponseDto(
+    public static DeleteProfileResponseDto of(Profile profile) {
+        return new DeleteProfileResponseDto(
                 profile.getId(),                                // 프로필 ID
                 profile.getUser() != null ? profile.getUser().getId() : null,  // 사용자 ID (User가 null일 경우 null 처리)
                 profile.getNickname(),                          // 사용자 닉네임

--- a/src/main/java/com/spring/instafeed/profile/entity/Profile.java
+++ b/src/main/java/com/spring/instafeed/profile/entity/Profile.java
@@ -8,9 +8,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @AllArgsConstructor
 public class Profile extends BaseEntity {
 
@@ -18,7 +20,8 @@ public class Profile extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)  // 한 명의 사용자에 대해 여러 프로필을 가질 수 있도록 변경
+    @JoinColumn(name = "user_id")
     private User user;
 
     private String nickname;
@@ -36,20 +39,21 @@ public class Profile extends BaseEntity {
     }
 
     /**
-     * 불변 객체를 위한 생성자
+     * Profile 클래스의 생성자입니다.
      *
-     * 이 생성자는 `Profile` 객체를 불변 객체로 생성하기 위해 사용됩니다.
-     * 주로 새로운 `Profile` 객체를 생성할 때 사용되며, 생성 시점에 모든 필드를 초기화합니다.
-     *
-     * @param user     프로필에 연관된 사용자 정보 (User 객체)
-     * @param nickname 사용자의 닉네임
-     * @param content  프로필에 대한 설명 또는 내용
-     * @param imagePath 프로필 이미지 경로
+     * @param user      이 프로필에 연결된 사용자 객체입니다.
+     *                  사용자 정보에 따라 프로필의 소유자가 결정됩니다.
+     * @param nickname  프로필에서 사용될 사용자 닉네임입니다.
+     *                  다른 사용자에게 표시되는 이름으로, 고유해야 할 수 있습니다.
+     * @param content   프로필에 대한 추가 정보 또는 설명입니다.
+     *                  사용자가 자신의 프로필에 대해 작성한 내용을 나타냅니다.
+     * @param imagePath 프로필 이미지의 경로입니다.
+     *                  이 경로는 사용자의 프로필 사진을 저장하는 위치를 나타냅니다.
      */
     public Profile(User user, String nickname, String content, String imagePath) {
-        this.user = user;          // 사용자 정보
-        this.nickname = nickname;  // 사용자 닉네임
-        this.content = content;    // 프로필 내용
-        this.imagePath = imagePath; // 프로필 이미지 경로
+        this.user = user;
+        this.nickname = nickname;
+        this.content = content;
+        this.imagePath = imagePath;
     }
 }

--- a/src/main/java/com/spring/instafeed/profile/repository/ProfileRepository.java
+++ b/src/main/java/com/spring/instafeed/profile/repository/ProfileRepository.java
@@ -2,8 +2,19 @@ package com.spring.instafeed.profile.repository;
 
 import com.spring.instafeed.profile.entity.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
+import java.util.Optional;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
-}
+    // 닉네임 중복 검사를 위한 메서드
+    boolean existsByNickname(String nickname);
 
+    // 특정 ID에 해당하는 삭제되지 않은 프로필을 조회하는 메소드
+    Optional<Profile> findByIdAndIsDeletedFalse(Long id);
+
+    // @Query를 사용하여 삭제되지 않은 모든 프로필을 조회하는 커스텀 쿼리 메소드
+    @Query("SELECT p FROM Profile p WHERE p.isDeleted = false")
+    List<Profile> findAllActiveProfiles();
+}

--- a/src/main/java/com/spring/instafeed/profile/service/ProfileService.java
+++ b/src/main/java/com/spring/instafeed/profile/service/ProfileService.java
@@ -3,6 +3,7 @@ package com.spring.instafeed.profile.service;
 import com.spring.instafeed.profile.dto.request.CreateProfileRequestDto;
 import com.spring.instafeed.profile.dto.request.UpdateProfileRequestDto;
 import com.spring.instafeed.profile.dto.response.CreateProfileResponseDto;
+import com.spring.instafeed.profile.dto.response.DeleteProfileResponseDto;
 import com.spring.instafeed.profile.dto.response.UpdateProfileResponseDto;
 import com.spring.instafeed.profile.entity.Profile;
 import com.spring.instafeed.profile.repository.ProfileRepository;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.http.HttpStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,35 +30,42 @@ public class ProfileService {
      * 프로필 생성
      *
      * 주어진 사용자 ID와 프로필 정보를 바탕으로 새로운 프로필을 생성합니다.
-     * 생성된 프로필은 데이터베이스에 저장되고, 저장된 프로필 정보를 DTO로 변환하여 반환합니다.
+     * 생성된 프로필은 데이터베이스에 저장되며, 저장된 프로필 정보를 DTO 형식으로 변환하여 반환합니다.
      *
      * @param userId                   사용자 ID
-     * @param createProfileRequestDto  생성할 프로필 정보
+     * @param createProfileRequestDto  프로필 생성 요청 DTO
      * @return CreateProfileResponseDto 생성된 프로필 정보를 담은 응답 DTO
-     * @throws ResponseStatusException 사용자 ID가 null이거나 사용자가 존재하지 않는 경우 예외 발생
+     * @throws ResponseStatusException 사용자 ID가 null이거나, 사용자가 존재하지 않으면 예외 발생
+     * @throws ResponseStatusException 닉네임이 중복되는 경우 예외 발생
      */
     @Transactional
     public CreateProfileResponseDto createProfile(Long userId, CreateProfileRequestDto createProfileRequestDto) {
+        // 사용자 ID가 null인지 확인
         if (userId == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "User ID must not be null");
         }
 
-        // userId로 User 엔티티를 조회
+        // 주어진 userId로 User 엔티티를 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
-        // Profile 엔티티 생성
+        // 입력받은 닉네임이 이미 다른 프로필에서 사용 중인지 확인
+        if (profileRepository.existsByNickname(createProfileRequestDto.getNickname())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Nickname already exists");
+        }
+
+        // 위의 검증을 모두 통과하면, 새로운 프로필 객체를 생성
         Profile profile = new Profile(
-                user,                             // 사용자 정보
-                createProfileRequestDto.getNickname(),  // 닉네임
-                createProfileRequestDto.getContent(),   // 프로필 내용
-                createProfileRequestDto.getImagePath()  // 프로필 이미지 경로
+                user,                             // 프로필에 해당하는 사용자 정보
+                createProfileRequestDto.getNickname(),  // 프로필에 설정할 닉네임
+                createProfileRequestDto.getContent(),   // 프로필에 설정할 내용
+                createProfileRequestDto.getImagePath()  // 프로필에 설정할 이미지 경로
         );
 
-        // 프로필 저장
+        // 생성된 프로필 객체를 데이터베이스에 저장
         Profile savedProfile = profileRepository.save(profile);
 
-        // 저장된 프로필 정보를 DTO로 변환하여 반환
+        // 저장된 프로필 정보를 DTO로 변환하여 응답
         return CreateProfileResponseDto.of(savedProfile);
     }
 
@@ -64,12 +73,13 @@ public class ProfileService {
      * 모든 프로필 목록 조회
      *
      * 데이터베이스에서 모든 프로필 정보를 조회하고, 이를 DTO로 변환하여 반환합니다.
+     * 이미 삭제된 프로필은 조회되지 않습니다.
      *
      * @return List<UpdateProfileResponseDto> 모든 프로필 정보 리스트
      */
     @Transactional(readOnly = true)
     public List<UpdateProfileResponseDto> getAllProfiles() {
-        List<Profile> profiles = profileRepository.findAll(); // 모든 프로필 조회
+        List<Profile> profiles = profileRepository.findAllActiveProfiles(); // 삭제되지 않은 프로필만 조회
         return profiles.stream()                             // 프로필 객체를 DTO로 변환
                 .map(UpdateProfileResponseDto::of)
                 .collect(Collectors.toList());
@@ -79,6 +89,7 @@ public class ProfileService {
      * 프로필 단건 조회
      *
      * 주어진 프로필 ID에 해당하는 프로필을 조회하고, 이를 DTO로 변환하여 반환합니다.
+     * 이미 삭제된 프로필은 조회되지 않습니다.
      *
      * @param id 조회할 프로필 ID
      * @return UpdateProfileResponseDto 조회된 프로필 정보
@@ -86,7 +97,7 @@ public class ProfileService {
      */
     @Transactional(readOnly = true)
     public UpdateProfileResponseDto getProfileById(Long id) {
-        Profile profile = profileRepository.findById(id)  // ID로 프로필 조회
+        Profile profile = profileRepository.findByIdAndIsDeletedFalse(id)  // ID로 프로필 조회, 삭제된 프로필은 제외
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found"));
 
         // 조회된 프로필 객체를 DTO로 변환하여 반환
@@ -96,31 +107,61 @@ public class ProfileService {
     /**
      * 프로필 수정
      *
-     * 주어진 프로필 ID에 해당하는 프로필을 수정하여 저장합니다.
-     * 수정된 프로필 정보는 DTO로 변환되어 반환됩니다.
+     * 주어진 프로필 ID에 해당하는 프로필을 수정합니다.
+     * 수정된 프로필 정보는 DTO 형태로 변환되어 반환됩니다.
+     * 프로필이 존재하지 않거나, 수정된 프로필에 대한 권한이 없으면 예외가 발생합니다.
      *
-     * @param id                         수정할 프로필 ID
-     * @param updatedProfileRequestDto   수정할 프로필 정보
-     * @return UpdateProfileResponseDto  수정된 프로필 정보
-     * @throws ResponseStatusException 프로필이 존재하지 않으면 예외 발생
+     * @param profileId                 수정할 프로필 ID
+     * @param updatedProfileRequestDto  수정할 프로필 정보 (닉네임, 내용, 이미지 경로 등)
+     * @return UpdateProfileResponseDto 수정된 프로필 정보를 담은 응답 DTO
+     * @throws ResponseStatusException 프로필이 존재하지 않거나, 사용자 권한이 일치하지 않는 경우 예외 발생
      */
     @Transactional
-    public UpdateProfileResponseDto updateProfile(Long id, UpdateProfileRequestDto updatedProfileRequestDto) {
-        Profile existingProfile = profileRepository.findById(id)  // ID로 기존 프로필 조회
+    public UpdateProfileResponseDto updateProfile(Long profileId, UpdateProfileRequestDto updatedProfileRequestDto) {
+        // 프로필 ID로 기존 프로필을 조회
+        Profile existingProfile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found"));
 
-        // 기존 프로필을 업데이트하여 새로운 Profile 객체 생성
-        existingProfile = new Profile(
-                existingProfile.getUser(),                  // 기존 사용자 유지
-                updatedProfileRequestDto.getNickname(),      // 새로운 닉네임
-                updatedProfileRequestDto.getContent(),       // 새로운 내용
-                updatedProfileRequestDto.getImagePath()      // 새로운 이미지 경로
-        );
+        // 프로필의 내용을 수정
+        existingProfile.setNickname(updatedProfileRequestDto.getNickname());
+        existingProfile.setContent(updatedProfileRequestDto.getContent());
+        existingProfile.setImagePath(updatedProfileRequestDto.getImagePath());
 
-        // 수정된 프로필 저장
+        // 수정된 프로필 객체를 데이터베이스에 저장
         Profile savedProfile = profileRepository.save(existingProfile);
 
         // 수정된 프로필을 DTO로 변환하여 반환
         return UpdateProfileResponseDto.of(savedProfile);
+    }
+
+
+    /**
+     * 프로필을 논리적으로 삭제합니다.
+     * 삭제된 프로필은 더 이상 조회되지 않으며,
+     * 실제 데이터베이스에서 제거되지 않고 삭제 플래그가 설정됩니다.
+     *
+     * @param id 삭제할 프로필의 ID
+     * @return 삭제된 프로필 정보를 포함하는 DeleteProfileResponseDto 객체
+     * @throws ResponseStatusException 프로필이 존재하지 않거나 이미 삭제된 경우 예외를 발생시킵니다.
+     */
+    @Transactional
+    public DeleteProfileResponseDto deleteProfile(Long id) {
+        Profile profile = profileRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found"));
+
+        // 이미 삭제된 프로필이라면 예외를 던짐
+        if (profile.getIsDeleted()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Profile is already deleted");
+        }
+
+        // 논리적 삭제 처리
+        profile.setIsDeleted(true);  // 삭제 플래그를 true로 설정
+        profile.setDeletedAt(LocalDateTime.now());  // 삭제 일자 기록
+
+        // 삭제된 프로필 저장
+        Profile deletedProfile = profileRepository.save(profile);
+
+        // 삭제된 프로필을 DTO로 변환하여 반환
+        return DeleteProfileResponseDto.of(deletedProfile);
     }
 }


### PR DESCRIPTION
- 하나의 userId가 여러개의 프로필id를 생성할 수 있도록 수정 (프로필 생성시 동일한 닉네임을 사용할 수 없도록 예외처리)
- Profile 엔티티를 불변 객체에서 가변 객체로 변경 (프로필과 관련된 데이터(팔로워, 게시물 등)의 일관성을 보장하기 위함)
- 프로필 삭제 기능 구현
- 프로필 중복 삭제요청시 예외처리
- 삭제된 프로필은 조회되지 않도록 처리
- BaseEntity클래스 isDeleted, deletedAt필드에 @Setter 어노테이션 추가