### PR TITLE
feat:  프로필 조회 응답DTO생성

### DIFF
--- a/src/main/java/com/spring/instafeed/profile/controller/ProfileController.java
+++ b/src/main/java/com/spring/instafeed/profile/controller/ProfileController.java
@@ -4,6 +4,7 @@ import com.spring.instafeed.profile.dto.request.CreateProfileRequestDto;
 import com.spring.instafeed.profile.dto.request.UpdateProfileRequestDto;
 import com.spring.instafeed.profile.dto.response.CreateProfileResponseDto;
 import com.spring.instafeed.profile.dto.response.DeleteProfileResponseDto;
+import com.spring.instafeed.profile.dto.response.QueryProfileResponseDto;
 import com.spring.instafeed.profile.dto.response.UpdateProfileResponseDto;
 import com.spring.instafeed.profile.service.ProfileService;
 import lombok.RequiredArgsConstructor;
@@ -44,12 +45,12 @@ public class ProfileController {
      * 프로필 목록 조회
      *
      * GET 요청을 통해 모든 프로필 목록을 조회하는 엔드포인트.
-     * 저장된 모든 프로필 정보를 `UpdateProfileResponseDto` 형식으로 반환한다.
+     * 저장된 모든 프로필 정보를 `QueryProfileResponseDto` 형식으로 반환한다.
      *
      * @return 모든 프로필 정보를 담은 리스트
      */
     @GetMapping
-    public List<UpdateProfileResponseDto> getAllProfiles() {
+    public List<QueryProfileResponseDto> getAllProfiles() {
         return profileService.getAllProfiles();
     }
 
@@ -63,7 +64,7 @@ public class ProfileController {
      * @return 조회된 프로필 정보를 담은 Response DTO
      */
     @GetMapping("/{id}")
-    public UpdateProfileResponseDto getProfileById(@PathVariable Long id) {
+    public QueryProfileResponseDto getProfileById(@PathVariable Long id) {
         return profileService.getProfileById(id);
     }
 

--- a/src/main/java/com/spring/instafeed/profile/dto/response/CreateProfileResponseDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/response/CreateProfileResponseDto.java
@@ -16,9 +16,6 @@ public class CreateProfileResponseDto {
     private final String content;
     private final String imagePath;
     private final LocalDateTime createdAt;
-    private final LocalDateTime updatedAt;
-    private final Boolean isDeleted;
-    private final LocalDateTime deletedAt;
 
     /**
      * Profile 객체를 CreateProfileResponseDto로 변환하는 static 메서드
@@ -37,10 +34,7 @@ public class CreateProfileResponseDto {
                 profile.getNickname(),                          // 사용자 닉네임
                 profile.getContent(),                           // 프로필 내용
                 profile.getImagePath(),                         // 프로필 이미지 경로
-                profile.getCreatedAt(),                         // 프로필 생성 일자
-                profile.getUpdatedAt(),                         // 프로필 수정 일자
-                profile.getIsDeleted(),                        // 프로필 삭제 여부
-                profile.getDeletedAt()                          // 프로필 삭제 일자
+                profile.getCreatedAt()                          // 프로필 생성 일자
         );
     }
 }

--- a/src/main/java/com/spring/instafeed/profile/dto/response/QueryProfileResponseDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/response/QueryProfileResponseDto.java
@@ -1,0 +1,28 @@
+package com.spring.instafeed.profile.dto.response;
+
+import com.spring.instafeed.profile.entity.Profile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QueryProfileResponseDto {
+
+    private final String nickname;    // 사용자 닉네임
+    private final String content;     // 프로필 내용
+    private final String imagePath;   // 프로필 이미지 경로
+
+    /**
+     * Profile 객체를 QueryProfileResponseDto로 변환하는 static 메서드
+     *
+     * @param profile 변환할 Profile 엔티티 객체
+     * @return Profile을 기반으로 생성된 QueryProfileResponseDto 객체
+     */
+    public static QueryProfileResponseDto of(Profile profile) {
+        return new QueryProfileResponseDto(
+                profile.getNickname(),        // 사용자 닉네임
+                profile.getContent(),         // 프로필 내용
+                profile.getImagePath()        // 프로필 이미지 경로
+        );
+    }
+}

--- a/src/main/java/com/spring/instafeed/profile/dto/response/UpdateProfileResponseDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/response/UpdateProfileResponseDto.java
@@ -18,8 +18,6 @@ public class UpdateProfileResponseDto {
     private final String imagePath;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
-    private final Boolean isDeleted;
-    private final LocalDateTime deletedAt;
 
     /**
      * Profile 객체를 UpdateProfileResponseDto로 변환하는 static 메서드
@@ -39,9 +37,7 @@ public class UpdateProfileResponseDto {
                 profile.getContent(),                           // 프로필 내용
                 profile.getImagePath(),                         // 프로필 이미지 경로
                 profile.getCreatedAt(),                         // 프로필 생성 일자
-                profile.getUpdatedAt(),                         // 프로필 수정 일자
-                profile.getIsDeleted(),                        // 프로필 삭제 여부
-                profile.getDeletedAt()                          // 프로필 삭제 일자
+                profile.getUpdatedAt()                          // 프로필 수정 일자
         );
     }
 }

--- a/src/main/java/com/spring/instafeed/profile/service/ProfileService.java
+++ b/src/main/java/com/spring/instafeed/profile/service/ProfileService.java
@@ -4,6 +4,7 @@ import com.spring.instafeed.profile.dto.request.CreateProfileRequestDto;
 import com.spring.instafeed.profile.dto.request.UpdateProfileRequestDto;
 import com.spring.instafeed.profile.dto.response.CreateProfileResponseDto;
 import com.spring.instafeed.profile.dto.response.DeleteProfileResponseDto;
+import com.spring.instafeed.profile.dto.response.QueryProfileResponseDto;
 import com.spring.instafeed.profile.dto.response.UpdateProfileResponseDto;
 import com.spring.instafeed.profile.entity.Profile;
 import com.spring.instafeed.profile.repository.ProfileRepository;
@@ -75,13 +76,13 @@ public class ProfileService {
      * 데이터베이스에서 모든 프로필 정보를 조회하고, 이를 DTO로 변환하여 반환합니다.
      * 이미 삭제된 프로필은 조회되지 않습니다.
      *
-     * @return List<UpdateProfileResponseDto> 모든 프로필 정보 리스트
+     * @return List<QueryProfileResponseDto> 모든 프로필 정보 리스트
      */
     @Transactional(readOnly = true)
-    public List<UpdateProfileResponseDto> getAllProfiles() {
+    public List<QueryProfileResponseDto> getAllProfiles() {
         List<Profile> profiles = profileRepository.findAllActiveProfiles(); // 삭제되지 않은 프로필만 조회
         return profiles.stream()                             // 프로필 객체를 DTO로 변환
-                .map(UpdateProfileResponseDto::of)
+                .map(QueryProfileResponseDto::of)
                 .collect(Collectors.toList());
     }
 
@@ -96,12 +97,12 @@ public class ProfileService {
      * @throws ResponseStatusException 프로필이 존재하지 않으면 예외 발생
      */
     @Transactional(readOnly = true)
-    public UpdateProfileResponseDto getProfileById(Long id) {
+    public QueryProfileResponseDto getProfileById(Long id) {
         Profile profile = profileRepository.findByIdAndIsDeletedFalse(id)  // ID로 프로필 조회, 삭제된 프로필은 제외
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Profile not found"));
 
         // 조회된 프로필 객체를 DTO로 변환하여 반환
-        return UpdateProfileResponseDto.of(profile);
+        return QueryProfileResponseDto.of(profile);
     }
 
     /**


### PR DESCRIPTION
-  프로필 조회시 불필요한 개인정보는 응답되지 않도록 QueryProfileResponseDto 추가 (기존에 응답되던 프로필아이디, 생성일/수정일/삭제일을 제외하고 닉네임, 소개글, 이미지만 응답되도록 수정)