### PR TITLE
feat: 생성일 수정일 추가

### DIFF
--- a/src/main/java/com/spring/instafeed/follower/dto/response/CreateFollowerResponseDto.java
+++ b/src/main/java/com/spring/instafeed/follower/dto/response/CreateFollowerResponseDto.java
@@ -3,11 +3,14 @@ package com.spring.instafeed.follower.dto.response;
 import com.spring.instafeed.base.Status;
 import com.spring.instafeed.follower.entity.Follower;
 
+import java.time.LocalDateTime;
+
 public record CreateFollowerResponseDto(
         Long id,
         Long senderProfileId,
         Long receiverProfileId,
-        Enum<Status> status
+        Enum<Status> status,
+        LocalDateTime createdAt
 ) {
     public static CreateFollowerResponseDto toDto(
             Follower follower
@@ -16,7 +19,8 @@ public record CreateFollowerResponseDto(
                 follower.getId(),
                 follower.getSenderProfile().getId(),
                 follower.getReceiverProfile().getId(),
-                follower.getStatus()
+                follower.getStatus(),
+                follower.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/spring/instafeed/follower/dto/response/UpdateFollowerResponseDto.java
+++ b/src/main/java/com/spring/instafeed/follower/dto/response/UpdateFollowerResponseDto.java
@@ -3,16 +3,22 @@ package com.spring.instafeed.follower.dto.response;
 import com.spring.instafeed.base.Status;
 import com.spring.instafeed.follower.entity.Follower;
 
+import java.time.LocalDateTime;
+
 public record UpdateFollowerResponseDto(
         Long id,
-        Status status
+        Status status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
     public static UpdateFollowerResponseDto toDto(
             Follower follower
     ) {
         return new UpdateFollowerResponseDto(
                 follower.getId(),
-                follower.getStatus()
+                follower.getStatus(),
+                follower.getCreatedAt(),
+                follower.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/spring/instafeed/newsfeed/controller/NewsfeedController.java
+++ b/src/main/java/com/spring/instafeed/newsfeed/controller/NewsfeedController.java
@@ -3,6 +3,7 @@ package com.spring.instafeed.newsfeed.controller;
 import com.spring.instafeed.newsfeed.dto.request.CreateNewsfeedRequestDto;
 import com.spring.instafeed.newsfeed.dto.request.UpdateNewsfeedRequestDto;
 import com.spring.instafeed.newsfeed.dto.response.*;
+import com.spring.instafeed.newsfeed.dto.response.ContentsWrapperResponseDto;
 import com.spring.instafeed.newsfeed.service.NewsfeedServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -51,22 +52,15 @@ public class NewsfeedController {
      * @return ResponseEntity<Page < NewsfeedResponseDto>> 페이징 처리된 게시물 목록
      */
     @GetMapping
-    public ResponseEntity<List<ReadNewsfeedResponseDto>> readAllNewsfeeds(
-            @RequestParam(value = "page", defaultValue = "0")
-            int page,  // 기본값은 첫 페이지
-            @RequestParam(value = "size", defaultValue = "10")
-            int size // 기본값은 10개 항목
+    public ResponseEntity<ContentsWrapperResponseDto> readAllNewsfeeds(
+            @RequestParam(value = "page", defaultValue = "1") int page, // 기본값: 1페이지
+            @RequestParam(value = "size", defaultValue = "10") int size // 기본값: 10개 항목
     ) {
-        page = Math.max(page - 1, 0);
-        // 사용자가 1 입력한다는 점 반영 및 음수가 되지 않도록 최솟값 설정
-
+        page = Math.max(page - 1, 0); // 1부터 시작하는 페이지 번호를 0부터 시작하도록 조정
         Pageable pageable = PageRequest.of(page, size);
 
-        List<ReadNewsfeedResponseDto> allNewsfeeds = new ArrayList<>();
-
-        allNewsfeeds = newsfeedService.readAllNewsfeeds(pageable);
-
-        return new ResponseEntity<>(allNewsfeeds, HttpStatus.OK);
+        ContentsWrapperResponseDto responseDto = newsfeedService.readAllNewsfeeds(pageable);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/com/spring/instafeed/newsfeed/dto/request/CreateNewsfeedRequestDto.java
+++ b/src/main/java/com/spring/instafeed/newsfeed/dto/request/CreateNewsfeedRequestDto.java
@@ -2,7 +2,7 @@ package com.spring.instafeed.newsfeed.dto.request;
 
 public record CreateNewsfeedRequestDto(
         Long profileId,
-        String content,
-        String imagePath
+        String imagePath,
+        String content
 ) {
 }

--- a/src/main/java/com/spring/instafeed/newsfeed/dto/response/ContentsWrapperResponseDto.java
+++ b/src/main/java/com/spring/instafeed/newsfeed/dto/response/ContentsWrapperResponseDto.java
@@ -1,0 +1,12 @@
+package com.spring.instafeed.newsfeed.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ContentsWrapperResponseDto {
+    private final List<ReadNewsfeedResponseDto> contents; // "contents"라는 키를 가지는 필드
+}

--- a/src/main/java/com/spring/instafeed/newsfeed/dto/response/CreateNewsfeedResponseDto.java
+++ b/src/main/java/com/spring/instafeed/newsfeed/dto/response/CreateNewsfeedResponseDto.java
@@ -2,19 +2,23 @@ package com.spring.instafeed.newsfeed.dto.response;
 
 import com.spring.instafeed.newsfeed.entity.Newsfeed;
 
+import java.time.LocalDateTime;
+
 public record CreateNewsfeedResponseDto(
         Long id,
         String nickname,
+        String imagePath,
         String content,
-        String imagePath
+        LocalDateTime createdAt
 ) {
 
     public static CreateNewsfeedResponseDto toDto(Newsfeed newsfeed) {
         return new CreateNewsfeedResponseDto(
                 newsfeed.getId(),
                 newsfeed.getProfile().getNickname(),
+                newsfeed.getImagePath(),
                 newsfeed.getContent(),
-                newsfeed.getImagePath()
+                newsfeed.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/spring/instafeed/newsfeed/dto/response/ReadNewsfeedResponseDto.java
+++ b/src/main/java/com/spring/instafeed/newsfeed/dto/response/ReadNewsfeedResponseDto.java
@@ -5,16 +5,16 @@ import com.spring.instafeed.newsfeed.entity.Newsfeed;
 public record ReadNewsfeedResponseDto(
         Long id,
         String nickname,
-        String content,
-        String imagePath
+        String imagePath,
+        String content
 ) {
 
     public static ReadNewsfeedResponseDto toDto(Newsfeed newsfeed) {
         return new ReadNewsfeedResponseDto(
                 newsfeed.getId(),
                 newsfeed.getProfile().getNickname(),
-                newsfeed.getContent(),
-                newsfeed.getImagePath()
+                newsfeed.getImagePath(),
+                newsfeed.getContent()
         );
     }
 }

--- a/src/main/java/com/spring/instafeed/newsfeed/dto/response/UpdateNewsfeedResponseDto.java
+++ b/src/main/java/com/spring/instafeed/newsfeed/dto/response/UpdateNewsfeedResponseDto.java
@@ -2,19 +2,25 @@ package com.spring.instafeed.newsfeed.dto.response;
 
 import com.spring.instafeed.newsfeed.entity.Newsfeed;
 
+import java.time.LocalDateTime;
+
 public record UpdateNewsfeedResponseDto(
         Long id,
         String nickname,
+        String imagePath,
         String content,
-        String imagePath
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
 
     public static UpdateNewsfeedResponseDto toDto(Newsfeed newsfeed) {
         return new UpdateNewsfeedResponseDto(
                 newsfeed.getId(),
                 newsfeed.getProfile().getNickname(),
+                newsfeed.getImagePath(),
                 newsfeed.getContent(),
-                newsfeed.getImagePath()
+                newsfeed.getCreatedAt(),
+                newsfeed.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/spring/instafeed/newsfeed/service/NewsfeedService.java
+++ b/src/main/java/com/spring/instafeed/newsfeed/service/NewsfeedService.java
@@ -13,7 +13,7 @@ public interface NewsfeedService {
             String imagePath
     );
 
-    List<ReadNewsfeedResponseDto> readAllNewsfeeds(Pageable pageable);
+    ContentsWrapperResponseDto readAllNewsfeeds(Pageable pageable);
 
     ReadNewsfeedResponseDto readNewsfeedById(Long id);
 

--- a/src/main/java/com/spring/instafeed/newsfeed/service/NewsfeedServiceImpl.java
+++ b/src/main/java/com/spring/instafeed/newsfeed/service/NewsfeedServiceImpl.java
@@ -1,6 +1,7 @@
 package com.spring.instafeed.newsfeed.service;
 
 import com.spring.instafeed.newsfeed.dto.response.*;
+import com.spring.instafeed.newsfeed.dto.response.ContentsWrapperResponseDto;
 import com.spring.instafeed.newsfeed.entity.Newsfeed;
 import com.spring.instafeed.newsfeed.repository.NewsfeedRepository;
 import com.spring.instafeed.profile.entity.Profile;
@@ -69,21 +70,19 @@ public class NewsfeedServiceImpl implements NewsfeedService {
      * @return List<ReadNewsfeedResponseDto> 일정 페이징 응답 DTO
      */
     @Override
-    public List<ReadNewsfeedResponseDto> readAllNewsfeeds(
-            Pageable pageable
-    ) {
+    public ContentsWrapperResponseDto readAllNewsfeeds(Pageable pageable) {
         Page<Newsfeed> allNewsfeeds = newsfeedRepository
                 .findAllByIsDeletedFalseOrderByUpdatedAtDesc(pageable);
 
-        List<ReadNewsfeedResponseDto> newsfeedList = new ArrayList<>();
-
-        newsfeedList = allNewsfeeds
+        // Newsfeed를 DTO로 변환
+        List<ReadNewsfeedResponseDto> newsfeedList = allNewsfeeds
                 .getContent()
                 .stream()
                 .map(ReadNewsfeedResponseDto::toDto)
                 .toList();
 
-        return newsfeedList;
+        // Wrapper DTO로 반환
+        return new ContentsWrapperResponseDto(newsfeedList);
     }
         /*
         [람다 반영 전 코드]

--- a/src/main/java/com/spring/instafeed/profile/dto/request/CreateProfileRequestDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/request/CreateProfileRequestDto.java
@@ -3,6 +3,6 @@ package com.spring.instafeed.profile.dto.request;
 public record CreateProfileRequestDto (
         Long userId,
         String nickname,
-        String content,
-        String imagePath
+        String imagePath,
+        String content
 ) {}

--- a/src/main/java/com/spring/instafeed/profile/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/request/UpdateProfileRequestDto.java
@@ -2,6 +2,6 @@ package com.spring.instafeed.profile.dto.request;
 
 public record UpdateProfileRequestDto (
         String nickname,
-        String content,
-        String imagePath
+        String imagePath,
+        String content
 ) {}

--- a/src/main/java/com/spring/instafeed/profile/dto/response/CreateProfileResponseDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/response/CreateProfileResponseDto.java
@@ -8,8 +8,8 @@ public record CreateProfileResponseDto(
         Long id,
         Long userId,
         String nickname,
-        String content,
         String imagePath,
+        String content,
         LocalDateTime createdAt
 ) {
     /**
@@ -23,8 +23,8 @@ public record CreateProfileResponseDto(
                 profile.getId(),
                 profile.getUser().getId(),
                 profile.getNickname(),
-                profile.getContent(),
                 profile.getImagePath(),
+                profile.getContent(),
                 profile.getCreatedAt()
         );
         // todo

--- a/src/main/java/com/spring/instafeed/profile/dto/response/DeleteProfileResponseDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/response/DeleteProfileResponseDto.java
@@ -7,8 +7,8 @@ import java.time.LocalDateTime;
 public record DeleteProfileResponseDto(
         Long id,
         String nickname,
-        String content,
         String imagePath,
+        String content,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         Boolean isDeleted,
@@ -25,8 +25,8 @@ public record DeleteProfileResponseDto(
         return new DeleteProfileResponseDto(
                 profile.getId(),
                 profile.getNickname(),
-                profile.getContent(),
                 profile.getImagePath(),
+                profile.getContent(),
                 profile.getCreatedAt(),
                 profile.getUpdatedAt(),
                 profile.getIsDeleted(),

--- a/src/main/java/com/spring/instafeed/profile/dto/response/UpdateProfileResponseDto.java
+++ b/src/main/java/com/spring/instafeed/profile/dto/response/UpdateProfileResponseDto.java
@@ -7,8 +7,8 @@ import java.time.LocalDateTime;
 public record UpdateProfileResponseDto(
         Long id,
         String nickname,
-        String content,
         String imagePath,
+        String content,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -23,8 +23,8 @@ public record UpdateProfileResponseDto(
         return new UpdateProfileResponseDto(
                 profile.getId(),
                 profile.getNickname(),
-                profile.getContent(),
                 profile.getImagePath(),
+                profile.getContent(),
                 profile.getCreatedAt(),
                 profile.getUpdatedAt()
         );

--- a/src/main/java/com/spring/instafeed/user/dto/response/ReadUserResponseDto.java
+++ b/src/main/java/com/spring/instafeed/user/dto/response/ReadUserResponseDto.java
@@ -2,10 +2,14 @@ package com.spring.instafeed.user.dto.response;
 
 import com.spring.instafeed.user.entity.User;
 
+import java.time.LocalDateTime;
+
 public record ReadUserResponseDto(
         Long id,
         String name,
-        String email
+        String email,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
 
     /**
@@ -29,7 +33,9 @@ public record ReadUserResponseDto(
         return new ReadUserResponseDto(
                 user.getId(),
                 user.getName(),
-                user.getEmail()
+                user.getEmail(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
         );
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=instafeed
 
 spring.datasource.url=jdbc:mysql://localhost:3306/instafeed
 spring.datasource.username=root
-spring.datasource.password=12345678
+spring.datasource.password=1234qwer!
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=create


### PR DESCRIPTION
feat: 생성일 수정일 추가
-유저정보 생성일, 비밀번호 수정일 추가
-프로필 생성일, 수정일은 기존에 있던 코드 사용
-팔로잉 요청 생성일, 요청 수정일 추가
-뉴스피드 수정일, 생성일 추가
-뉴스피드 목록 조회 contents부제목 응답되도록 추가 
 (ContentsWrapperResponseDto 클래스 추가됨)

TODO: 회원탈퇴 시 탈퇴 일자를 저장하여 활성 사용자와 구분 및 데이터 복구 가능성 관리.